### PR TITLE
Additional Visual Cues Attached to Links

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ button:focus,input[type="button"]:focus,input[type="reset"]:focus,input[type="su
 input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"],textarea{color:#666;border:1px solid #ccc;border-radius:3px}
 input[type="text"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="password"]:focus,input[type="search"]:focus,textarea:focus{color:#111}
 input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"]{padding:3px}
-textarea{padding-left:3px;width:100%}a{color:royalblue}a:visited{color:purple}a:hover,a:focus,a:active{color:midnightblue}
+textarea{padding-left:3px;width:100%}a{color:royalblue; text-decoration: underline}a:visited{color:purple; text-decoration: underline}a:hover,a:focus,a:active{color:midnightblue; text-decoration: underline}
 a:focus{outline:thin dotted}a:hover,a:active{outline:0}.main-navigation{clear:both;display:block;float:left;width:100%}
 .main-navigation ul{display:none;list-style:none;margin:0;padding-left:0}.main-navigation li{float:left;position:relative}
 .main-navigation a{display:block;text-decoration:none}.main-navigation ul ul{-webkit-box-shadow:0 3px 3px rgba(0,0,0,0.2);box-shadow:0 3px 3px rgba(0,0,0,0.2);float:left;position:absolute;top:1.5em;left:-999em;z-index:99999}

--- a/style.css
+++ b/style.css
@@ -43,7 +43,7 @@ button:focus,input[type="button"]:focus,input[type="reset"]:focus,input[type="su
 input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"],textarea{color:#666;border:1px solid #ccc;border-radius:3px}
 input[type="text"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="password"]:focus,input[type="search"]:focus,textarea:focus{color:#111}
 input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"]{padding:3px}
-textarea{padding-left:3px;width:100%}a{color:royalblue; text-decoration: underline}a:visited{color:purple; text-decoration: underline}a:hover,a:focus,a:active{color:midnightblue; text-decoration: underline}
+textarea{padding-left:3px;width:100%}a{color:royalblue; text-decoration: underline}a:visited{color:purple; text-decoration: underline; font-style: italic}a:hover,a:focus,a:active{color:midnightblue; text-decoration: underline; font-weight: bold}
 a:focus{outline:thin dotted}a:hover,a:active{outline:0}.main-navigation{clear:both;display:block;float:left;width:100%}
 .main-navigation ul{display:none;list-style:none;margin:0;padding-left:0}.main-navigation li{float:left;position:relative}
 .main-navigation a{display:block;text-decoration:none}.main-navigation ul ul{-webkit-box-shadow:0 3px 3px rgba(0,0,0,0.2);box-shadow:0 3px 3px rgba(0,0,0,0.2);float:left;position:absolute;top:1.5em;left:-999em;z-index:99999}


### PR DESCRIPTION
### Stories pages accessibility issue- Links are not clearly identifiable

According to _WCAG Guideline 1.4.1- Use Of Color_, color must not be used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.

Currently, the only visual cue distinguishing links from other text on the stories pages is a change of color. This can prevent people who cannot perceive color differences from identifying the links and interacting with them.

To fix this, I am adding the following visual cues to the different link selectors in **style.css**:

- **a{}** 
1. text-decoration: underline

- **a:visited{}** 
1. text-decoration: underline
2. font-style: italic

- **a:hover,a:focus,a:active{}** 
1. text-decoration: underline
2. font-weight: bold